### PR TITLE
prevent online tile fetches from blocking offline mbtiles rendering

### DIFF
--- a/src/boot/api.js
+++ b/src/boot/api.js
@@ -119,11 +119,14 @@ class FetchClient {
   }
 
   async getTileImage (tile, tileUrl, useAuth = false) {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), 5000)
     try {
       const headers = useAuth ? {} : { Authorization: null }
       const response = await this.get(tileUrl, {
         responseType: 'arraybuffer',
-        headers
+        headers,
+        signal: controller.signal
       })
       const blob = new Blob([response.data], { type: 'image/png' })
       const blobUrl = URL.createObjectURL(blob)
@@ -134,6 +137,8 @@ class FetchClient {
       img.src = blobUrl
     } catch (error) {
       tile.setState(TileState.ERROR)
+    } finally {
+      clearTimeout(timer)
     }
   }
 }

--- a/src/boot/api.js
+++ b/src/boot/api.js
@@ -120,7 +120,7 @@ class FetchClient {
 
   async getTileImage (tile, tileUrl, useAuth = false) {
     const controller = new AbortController()
-    const timer = setTimeout(() => controller.abort(), 5000)
+    const timer = setTimeout(() => controller.abort(), 15000)
     try {
       const headers = useAuth ? {} : { Authorization: null }
       const response = await this.get(tileUrl, {

--- a/src/components/map/layers/CartoLayers.vue
+++ b/src/components/map/layers/CartoLayers.vue
@@ -143,7 +143,6 @@ export default {
         newLayer = new VectorTileLayer({
           source: active.source,
           visible: active.visible !== false,
-          zIndex: 10,
           properties: layerProps
         })
 
@@ -171,7 +170,6 @@ export default {
         newLayer = new TileLayer({
           source: active.source,
           visible: active.visible !== false,
-          zIndex: 10,
           properties: layerProps
         })
       }
@@ -242,9 +240,6 @@ export default {
       const transformRequest = (url, type) => {
         if (type === 'Tiles') {
           url = url.replace(/\/tile\//, '/VectorTileServer/tile/')
-          const tileController = new AbortController()
-          setTimeout(() => tileController.abort(), 4000)
-          return new Request(url, { signal: tileController.signal })
         }
         return new Request(url)
       }
@@ -254,13 +249,13 @@ export default {
 
         const basemapStyleResp = await fetchWithTimeout(
           'https://cdn.arcgis.com/sharing/rest/content/items/165d7a1e43164d828064eb2027e219d5/resources/styles/root.json?f=json',
-          6000
+          15000
         )
         await applyStyle(basemapLayer, await basemapStyleResp.json(), { transformRequest })
 
         const contoursStyleResp = await fetchWithTimeout(
           'https://cdn.arcgis.com/sharing/rest/content/items/51ca3ce6a16d4080ad955dacd6dd2fe2/resources/styles/root.json?f=json',
-          6000
+          15000
         )
         await applyStyle(contoursLayer, await contoursStyleResp.json(), { transformRequest })
       } catch (e) {

--- a/src/components/map/layers/CartoLayers.vue
+++ b/src/components/map/layers/CartoLayers.vue
@@ -60,14 +60,12 @@ export default {
       if (!map) return
 
       const basemap = map.getLayers().getArray().find(l => l.get('name') === 'vector-basemap')
-      const contours = map.getLayers().getArray().find(l => l.get('name') === 'vector-contours')
 
       if (online && !basemap) {
         this.initVectorBasemap(map)
-      } else {
-        if (basemap) basemap.setVisible(online)
-        if (contours) contours.setVisible(online)
       }
+
+      this.syncBasemapVisibility(map)
 
       if (!online) {
         for (const [key, active] of Object.entries(this.offlineMapsStore.activeSources)) {
@@ -99,16 +97,21 @@ export default {
           this.removeOfflineLayer(key)
         }
       }
+
+      const map = this.getMap()
+      if (map) this.syncBasemapVisibility(map)
     }
   },
-  async mounted () {
+  mounted () {
     const map = this.getMap()
     if (map) {
-      await this.initVectorBasemap(map)
+      this.initVectorBasemap(map)
     }
-    for (const key of Object.keys(this.offlineMapsStore.activeSources)) {
-      await this.addOfflineLayer(key)
-    }
+    Promise.all(
+      Object.keys(this.offlineMapsStore.activeSources).map(key => this.addOfflineLayer(key))
+    ).then(() => {
+      if (map) this.syncBasemapVisibility(map)
+    })
     this.mapStore.getCavesLayerSource().then(source => {
       this.cavesSource.vectorLayer.setSource(source)
     })
@@ -140,6 +143,7 @@ export default {
         newLayer = new VectorTileLayer({
           source: active.source,
           visible: active.visible !== false,
+          zIndex: 10,
           properties: layerProps
         })
 
@@ -167,6 +171,7 @@ export default {
         newLayer = new TileLayer({
           source: active.source,
           visible: active.visible !== false,
+          zIndex: 10,
           properties: layerProps
         })
       }
@@ -176,6 +181,8 @@ export default {
       const cavesIdx = cavesLayer ? layers.getArray().indexOf(cavesLayer) : -1
       const insertIdx = cavesIdx >= 0 ? cavesIdx : 0
       layers.insertAt(insertIdx, newLayer)
+
+      this.syncBasemapVisibility(map)
     },
 
     setOfflineLayerVisibility (key, visible) {
@@ -188,6 +195,23 @@ export default {
       if (layer) {
         layer.setVisible(visible !== false)
       }
+
+      this.syncBasemapVisibility(map)
+    },
+
+    hasVisibleOfflineLayer () {
+      for (const active of Object.values(this.offlineMapsStore.activeSources)) {
+        if (active?.visible) return true
+      }
+      return false
+    },
+
+    syncBasemapVisibility (map) {
+      const basemap = map.getLayers().getArray().find(l => l.get('name') === 'vector-basemap')
+      const contours = map.getLayers().getArray().find(l => l.get('name') === 'vector-contours')
+      const shouldShow = isOnline.value && !this.hasVisibleOfflineLayer()
+      if (basemap) basemap.setVisible(shouldShow)
+      if (contours) contours.setVisible(shouldShow)
     },
 
     async initVectorBasemap (map) {
@@ -196,19 +220,31 @@ export default {
       }
 
       const basemapLayer = new VectorTileLayer({
-        properties: { name: 'vector-basemap' }
+        properties: { name: 'vector-basemap' },
+        visible: !this.hasVisibleOfflineLayer()
       })
       const contoursLayer = new VectorTileLayer({
         properties: { name: 'vector-contours' },
-        minZoom: 10
+        minZoom: 10,
+        visible: !this.hasVisibleOfflineLayer()
       })
 
       map.getLayers().insertAt(0, basemapLayer)
       map.getLayers().insertAt(1, contoursLayer)
 
+      const fetchWithTimeout = (url, ms) => {
+        const controller = new AbortController()
+        const timer = setTimeout(() => controller.abort(), ms)
+        return fetch(url, { signal: controller.signal })
+          .finally(() => clearTimeout(timer))
+      }
+
       const transformRequest = (url, type) => {
         if (type === 'Tiles') {
           url = url.replace(/\/tile\//, '/VectorTileServer/tile/')
+          const tileController = new AbortController()
+          setTimeout(() => tileController.abort(), 4000)
+          return new Request(url, { signal: tileController.signal })
         }
         return new Request(url)
       }
@@ -216,13 +252,15 @@ export default {
       try {
         const { applyStyle } = await import('ol-mapbox-style')
 
-        const basemapStyleResp = await fetch(
-          'https://cdn.arcgis.com/sharing/rest/content/items/165d7a1e43164d828064eb2027e219d5/resources/styles/root.json?f=json'
+        const basemapStyleResp = await fetchWithTimeout(
+          'https://cdn.arcgis.com/sharing/rest/content/items/165d7a1e43164d828064eb2027e219d5/resources/styles/root.json?f=json',
+          6000
         )
         await applyStyle(basemapLayer, await basemapStyleResp.json(), { transformRequest })
 
-        const contoursStyleResp = await fetch(
-          'https://cdn.arcgis.com/sharing/rest/content/items/51ca3ce6a16d4080ad955dacd6dd2fe2/resources/styles/root.json?f=json'
+        const contoursStyleResp = await fetchWithTimeout(
+          'https://cdn.arcgis.com/sharing/rest/content/items/51ca3ce6a16d4080ad955dacd6dd2fe2/resources/styles/root.json?f=json',
+          6000
         )
         await applyStyle(contoursLayer, await contoursStyleResp.json(), { transformRequest })
       } catch (e) {
@@ -241,6 +279,8 @@ export default {
       if (layerToRemove) {
         map.removeLayer(layerToRemove)
       }
+
+      this.syncBasemapVisibility(map)
     }
   }
 }

--- a/src/components/map/layers/CustomWMTSLayer.vue
+++ b/src/components/map/layers/CustomWMTSLayer.vue
@@ -6,6 +6,7 @@
 <script>
 import { ref } from 'vue'
 import WMTS, { optionsFromCapabilities } from 'ol/source/WMTS'
+import TileState from 'ol/TileState'
 import { useMapStore } from 'stores/map-store'
 import { db } from 'src/db/db'
 import { api } from 'src/boot/api'
@@ -34,10 +35,18 @@ export default {
         crossOrigin: 'anonymous'
       }
       options.tileLoadFunction = async (imageTile, src) => {
+        if (this.layerRef?.tileLayer?.getVisible() === false) {
+          imageTile.setState(TileState.ERROR)
+          return
+        }
         const image = imageTile.getImage()
         const storedTile = await db.tiles.where('tileKey')
           .equals(src)
           .first()
+        if (this.layerRef?.tileLayer?.getVisible() === false) {
+          imageTile.setState(TileState.ERROR)
+          return
+        }
         if (!storedTile) {
           api.getTileImage(imageTile, src, true)
 


### PR DESCRIPTION
On poor cellular signal, switching to an offline mbtiles layer would
either not render or take a long time. Airplane mode worked because it
short-circuited online fetches. Three fixes:

- CartoLayers: don't await initVectorBasemap in mounted, parallelize
  addOfflineLayer calls, add 6s timeout to ArcGIS style fetches and 4s
  per-tile timeout, hide vector basemap+contours whenever an offline
  layer is visible (via syncBasemapVisibility), give offline layers
  zIndex 10 so they always paint on top.
- api.getTileImage: 5s AbortController timeout so cached-WMTS misses
  on bad signal don't hold connection slots indefinitely.
- CustomWMTSLayer: bail out of tileLoadFunction when the layer is
  hidden so layer switching doesn't leave stale fetches in flight.